### PR TITLE
chore: hack19-catchet to 0.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -13,3 +13,6 @@ dependencies:
 - name: go-web
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.13
+- name: hack19-catchet
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.4


### PR DESCRIPTION
chore: Promote hack19-catchet to version 0.0.4