### PR TITLE
chore: hack19-catchet to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,4 +15,4 @@ dependencies:
   version: 0.0.13
 - name: hack19-catchet
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.9


### PR DESCRIPTION
chore: Promote hack19-catchet to version 0.0.9